### PR TITLE
Default to ExponentialRetry, not RetryOptions

### DIFF
--- a/aiohttp_retry/__init__.py
+++ b/aiohttp_retry/__init__.py
@@ -181,7 +181,7 @@ class RetryClient:
     def __init__(
         self,
         logger: Optional[_Logger] = None,
-        retry_options: RetryOptionsBase = RetryOptions(),
+        retry_options: RetryOptionsBase = ExponentialRetry(),
         *args: Any, **kwargs: Any
     ) -> None:
         self._client = ClientSession(*args, **kwargs)


### PR DESCRIPTION
As RetryOptions is now deprecated, this means that a warning is emitted,
even though RetryOptions is not used anywhere in the client code