### PR TITLE
fix retries

### DIFF
--- a/aiohttp_retry/client.py
+++ b/aiohttp_retry/client.py
@@ -64,12 +64,12 @@ class _RequestContext:
     async def _do_request(self) -> ClientResponse:
         current_attempt = 0
         while True:
-            current_attempt += 1
-            self._logger.debug("Attempt {} out of {}".format(current_attempt, self._retry_options.attempts))
-            if current_attempt > 1:
+            self._logger.debug(f"Attempt {current_attempt+1} out of {self._retry_options.attempts}")
+            if current_attempt > 0:
                 retry_wait = self._retry_options.get_timeout(current_attempt)
                 await asyncio.sleep(retry_wait)
 
+            current_attempt += 1
             try:
                 response: ClientResponse = await self._request(
                     self._method,


### PR DESCRIPTION
hey @inyutin thanks for this awesome library!

It seems that https://github.com/inyutin/aiohttp_retry/pull/66 broke the list retry option using >1 attemps, because the `current_attempt` is now incremented before the `get_timeout` call. This leads to an `IndexError: list index out of range` error.

This PR reverts the change while preserving the logging output which was improved in https://github.com/inyutin/aiohttp_retry/pull/66.

I didn't really know where to put this regression test, happy to move it elsewhere.

cheers

