### PR TITLE
Require python 3.7 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=["tests", "tests.*"]),
     platforms=['any'],
+    python_requires='>=3.7',
     install_requires=[
         'aiohttp',
     ],


### PR DESCRIPTION
Hi @inyutin - now that the library expects Python 3.7 or higher, let's also explicitly require the same in `setup.py`?

This would help projects that use tools like `pip-tools` or `poetry`, to better resolve the supported library version when locking the requirements.


Thanks!