### PR TITLE
ENH: test against python 3.10 and 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
just trying to avoid surprises 

edit: interestingly I see 3.6 listed "waiting" but there is no 3.6 in the workflow, odd