### PR TITLE
Fix the client sometimes would not retry

### DIFF
--- a/aiohttp_retry/client.py
+++ b/aiohttp_retry/client.py
@@ -89,7 +89,7 @@ class _RequestContext:
         if current_attempt == self._retry_options.attempts:
             return True
 
-        if response.method not in self._retry_options.methods:
+        if response.method.upper() not in self._retry_options.methods:
             return True
 
         if response.status >= _MIN_SERVER_ERROR_STATUS and self._retry_options.retry_all_server_errors:

--- a/aiohttp_retry/retry_options.py
+++ b/aiohttp_retry/retry_options.py
@@ -32,7 +32,7 @@ class RetryOptionsBase:
 
         if methods is None:
             methods = {"HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE", "POST", "CONNECT", "PATCH"}
-        self.methods: Iterable[str] = methods
+        self.methods: Iterable[str] = {method.upper() for method in methods}
 
         self.retry_all_server_errors = retry_all_server_errors
         self.evaluate_response_callback = evaluate_response_callback

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -349,7 +349,18 @@ async def test_list_retry_works_for_multiple_attempts(aiohttp_client: pytest_aio
 async def test_dont_retry_if_not_in_retry_methods(aiohttp_client: pytest_aiohttp.plugin.AiohttpClient) -> None:
     retry_client, test_app = await get_retry_client_and_test_app_for_test(
         aiohttp_client,
-        retry_options=ExponentialRetry(methods={"POST"}),  # not "GET"
+        retry_options=ExponentialRetry(),  # try on all methods by default
+    )
+
+    async with retry_client.get("/internal_error") as response:
+        assert response.status == 500
+        assert test_app.counter == 3
+
+    await retry_client.close()
+
+    retry_client, test_app = await get_retry_client_and_test_app_for_test(
+        aiohttp_client,
+        retry_options=ExponentialRetry(methods={"POST"}),  # try on only POST method
     )
 
     async with retry_client.get("/internal_error") as response:


### PR DESCRIPTION
Resolves #108 
After upgrading `2.9.0`, sometimes the retry would not works as expected.
The temporary solution is downgrading to `2.8.3`.

# Root cause
This issue is inducted by the mechanism of checking whether skip the retry:
https://github.com/inyutin/aiohttp_retry/blob/5ea8c8eab3706617011b5ba7ff0a86cec5c4182a/aiohttp_retry/client.py#L92-L93
Sometimes, `response.method` is the **string in lowercase** (such as `get`) while `self._retry_options.methods` is **a set of uppercase strings** (such as `{'GET', 'POST'}`), the retry will be skipped, which does not match the expectation.

# Solution
Ensure the method string is comparing in the same case.