### PR TITLE
Fix default retry exception set to all exceptions

### DIFF
--- a/aiohttp_retry/retry_options.py
+++ b/aiohttp_retry/retry_options.py
@@ -27,7 +27,7 @@ class RetryOptionsBase:
         self.statuses: Iterable[int] = statuses
 
         if exceptions is None:
-            exceptions = set()
+            exceptions = {Exception}
         self.exceptions: Iterable[type[Exception]] = exceptions
 
         if methods is None:


### PR DESCRIPTION
This parameter is [documented][1] as applying to all exceptions by default, but `any()` [used here][2] of an [empty set][3] is `False`.

[1]: https://github.com/inyutin/aiohttp_retry/blob/1a3bc19e15de202755e5cdf67c1c011aef2926c9/aiohttp_retry/retry_options.py#L18
[2]: https://github.com/inyutin/aiohttp_retry/blob/1a3bc19e15de202755e5cdf67c1c011aef2926c9/aiohttp_retry/client.py#L144
[3]: https://github.com/inyutin/aiohttp_retry/blob/1a3bc19e15de202755e5cdf67c1c011aef2926c9/aiohttp_retry/retry_options.py#L30