### PR TITLE
Upgrade mypy, pytest-aiohttp, pytest, and ruff

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,8 +10,9 @@ jobs:
   test_package:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
     - uses: actions/checkout@master

--- a/aiohttp_retry/client.py
+++ b/aiohttp_retry/client.py
@@ -107,7 +107,7 @@ class _RequestContext:
         current_attempt = 0
 
         while True:
-            self._logger.debug(f"Attempt {current_attempt+1} out of {self._retry_options.attempts}")
+            self._logger.debug(f"Attempt {current_attempt + 1} out of {self._retry_options.attempts}")
 
             current_attempt += 1
             try:

--- a/requirements_ci.txt
+++ b/requirements_ci.txt
@@ -1,4 +1,4 @@
-mypy==1.4.1  # last version that support python 3.7
-pytest-aiohttp==1.0.5
-pytest==7.4.4  # last version that support python 3.7
-ruff==0.7.1
+mypy
+pytest-aiohttp
+pytest
+ruff


### PR DESCRIPTION
Python < 3.10 are end-of-life.  https://devguide.python.org/versions
* #119

Also, https://pypi.org/project/typed-ast is end-of-life

https://docs.astral.sh/ruff

@inyutin Your review, please.