### PR TITLE
Add start_time parameter to get_timeout()

### DIFF
--- a/aiohttp_retry/client.py
+++ b/aiohttp_retry/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from abc import abstractmethod
 from collections.abc import Awaitable, Callable, Generator
 from dataclasses import dataclass
@@ -96,6 +97,7 @@ class _RequestContext:
 
     async def _do_request(self) -> ClientResponse:
         current_attempt = 0
+        start_time = time.monotonic()
 
         while True:
             self._logger.debug(f"Attempt {current_attempt+1} out of {self._retry_options.attempts}")
@@ -126,7 +128,9 @@ class _RequestContext:
                         response.raise_for_status()
                     self._response = response
                     return self._response
-                retry_wait = self._retry_options.get_timeout(attempt=current_attempt, response=response)
+                retry_wait = self._retry_options.get_timeout(
+                    attempt=current_attempt, response=response, start_time=start_time,
+                )
 
             except Exception as e:
                 if current_attempt >= self._retry_options.attempts:
@@ -137,7 +141,9 @@ class _RequestContext:
                     raise
 
                 debug_message = f"Retrying after exception: {e!r}"
-                retry_wait = self._retry_options.get_timeout(attempt=current_attempt, response=None)
+                retry_wait = self._retry_options.get_timeout(
+                    attempt=current_attempt, response=None, start_time=start_time,
+                )
 
             self._logger.debug(debug_message)
             await asyncio.sleep(retry_wait)

--- a/aiohttp_retry/retry_options.py
+++ b/aiohttp_retry/retry_options.py
@@ -39,7 +39,12 @@ class RetryOptionsBase:
         self.evaluate_response_callback = evaluate_response_callback
 
     @abc.abstractmethod
-    def get_timeout(self, attempt: int, response: ClientResponse | None = None) -> float:
+    def get_timeout(
+        self,
+        attempt: int,
+        response: ClientResponse | None = None,
+        start_time: float | None = None,
+    ) -> float:
         raise NotImplementedError
 
 
@@ -73,6 +78,7 @@ class ExponentialRetry(RetryOptionsBase):
         self,
         attempt: int,
         response: ClientResponse | None = None,  # noqa: ARG002
+        start_time: float | None = None,  # noqa: ARG002
     ) -> float:
         """Return timeout with exponential backoff."""
         timeout = self._start_timeout * (self._factor**attempt)
@@ -115,6 +121,7 @@ class RandomRetry(RetryOptionsBase):
         self,
         attempt: int,  # noqa: ARG002
         response: ClientResponse | None = None,  # noqa: ARG002
+        start_time: float | None = None,  # noqa: ARG002
     ) -> float:
         """Generate random timeouts."""
         return self.min_timeout + self.random() * (self.max_timeout - self.min_timeout)
@@ -144,6 +151,7 @@ class ListRetry(RetryOptionsBase):
         self,
         attempt: int,
         response: ClientResponse | None = None,  # noqa: ARG002
+        start_time: float | None = None,  # noqa: ARG002
     ) -> float:
         """Timeouts from a defined list."""
         return self.timeouts[attempt]
@@ -179,6 +187,7 @@ class FibonacciRetry(RetryOptionsBase):
         self,
         attempt: int,  # noqa: ARG002
         response: ClientResponse | None = None,  # noqa: ARG002
+        start_time: float | None = None,  # noqa: ARG002
     ) -> float:
         new_current_step = self.prev_step + self.current_step
         self.prev_step = self.current_step
@@ -224,6 +233,7 @@ class JitterRetry(ExponentialRetry):
         self,
         attempt: int,
         response: ClientResponse | None = None,  # noqa: ARG002
+        start_time: float | None = None,  # noqa: ARG002
     ) -> float:
-        timeout: float = super().get_timeout(attempt) + random.uniform(0, self._random_interval_size) ** self._factor
+        timeout: float = super().get_timeout(attempt, response, start_time) + random.uniform(0, self._random_interval_size) ** self._factor
         return timeout

--- a/tests/test_retry_options.py
+++ b/tests/test_retry_options.py
@@ -54,3 +54,38 @@ def test_jitter_retry() -> None:
     ]
     for idx, timeout in enumerate(timeouts):
         assert abs(timeout - expected[idx]) < 0.1
+
+
+def test_start_time_passed_to_get_timeout() -> None:
+    """Existing strategies ignore start_time (backward compatible)."""
+    retry = ExponentialRetry(attempts=5)
+    # With start_time=None (default) and start_time=some value, result is the same
+    for attempt in range(5):
+        assert retry.get_timeout(attempt) == retry.get_timeout(attempt, start_time=None)
+        assert retry.get_timeout(attempt) == retry.get_timeout(attempt, start_time=12345.0)
+
+
+def test_subclass_can_read_start_time() -> None:
+    """Custom strategies can access start_time in get_timeout.
+
+    A realistic use (cumulative scheduling as in issue #121) would also need
+    time.monotonic() to compute elapsed time, which is too much to mock here.
+    This test just verifies the parameter arrives.
+    """
+
+    class StartTimeAwareRetry(ExponentialRetry):
+        def get_timeout(
+            self,
+            attempt: int,
+            response=None,
+            start_time: float | None = None,
+        ) -> float:
+            if start_time is not None:
+                return start_time  # just echo it back
+            return super().get_timeout(attempt)
+
+    retry = StartTimeAwareRetry(attempts=5)
+
+    assert retry.get_timeout(attempt=1, start_time=42.0) == 42.0
+    assert retry.get_timeout(attempt=1, start_time=0.0) == 0.0
+    assert retry.get_timeout(attempt=1) == retry.get_timeout(attempt=1, start_time=None)


### PR DESCRIPTION
Adds `start_time: float | None = None` to `get_timeout()` on `RetryOptionsBase` and all subclasses, and passes `time.monotonic()` from `_RequestContext._do_request()` before the retry loop. Existing strategies ignore the parameter (backward compatible). Custom subclasses can use it for cumulative scheduling where jitter mean-reverts across attempts.

Also updates `JitterRetry.get_timeout()` to forward `response` and `start_time` through its `super().get_timeout()` call, so subclasses of `ExponentialRetry` that override `get_timeout` to use these parameters will receive them correctly.

Closes #121