### PR TITLE
Fix exceptions=None: should retry on all exceptions, not none

### DIFF
--- a/aiohttp_retry/client.py
+++ b/aiohttp_retry/client.py
@@ -141,7 +141,10 @@ class _RequestContext:
                 if current_attempt >= self._retry_options.attempts:
                     raise
 
-                is_exc_valid = any(isinstance(e, exc) for exc in self._retry_options.exceptions)
+                is_exc_valid = (
+                    self._retry_options.exceptions is None
+                    or any(isinstance(e, exc) for exc in self._retry_options.exceptions)
+                )
                 if not is_exc_valid:
                     raise
 

--- a/aiohttp_retry/retry_options.py
+++ b/aiohttp_retry/retry_options.py
@@ -26,9 +26,7 @@ class RetryOptionsBase:
             statuses = set()
         self.statuses: Iterable[int] = statuses
 
-        if exceptions is None:
-            exceptions = set()
-        self.exceptions: Iterable[type[Exception]] = exceptions
+        self.exceptions: Iterable[type[Exception]] | None = exceptions
 
         if methods is None:
             methods = {"HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE", "POST", "CONNECT", "PATCH"}


### PR DESCRIPTION
The `exceptions` parameter in `RetryOptionsBase` has a comment saying `# On which exceptions we should retry, by default on all`, meaning `exceptions=None` should retry on every exception.

But the current code does:
```python
if exceptions is None:
    exceptions = set()
self.exceptions = exceptions
```

This converts `None` to an empty set. Then in `client.py`:
```python
is_exc_valid = any(isinstance(e, exc) for exc in self._retry_options.exceptions)
```
`any(... for exc in set())` always returns `False`, so exceptions are never retried when `exceptions=None` -- the opposite of what the docs say.

Fix:
- Keep `self.exceptions` as `None` when not specified
- In `_do_request`, treat `None` as "retry on all exceptions"

This makes the default behavior consistent with the documented intent.